### PR TITLE
Remove redundant conversions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,11 +11,11 @@ jobs:
           - windows-latest
         nim-version:
           - stable
-          - 1.6.0
+          - 2.2.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: jiro4989/setup-nim-action@v1
+      - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: ${{ matrix.nim-version }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/durations.nimble
+++ b/durations.nimble
@@ -8,4 +8,4 @@ license       = "Apache-2.0"
 
 # Dependencies
 
-requires "nim >= 1.6.0"
+requires "nim >= 2.1.9"

--- a/durations/core.nim
+++ b/durations/core.nim
@@ -58,13 +58,13 @@ func to*[R1, R2](d: Duration[R1]; outType: typedesc[Duration[R2]]): Duration[R2]
   when R1 == R2:
     d
   else:
-    const conversion = R1 / R2.Ratio # ???
+    const conversion = R1 / R2
     Duration[R2](count: (d.count * conversion).toCount)
 
 template operatorImpl[R1, R2](d1: Duration[R1]; d2: Duration[R2]; expression: untyped; wrap = false): untyped =
   const commonRatio =
-    when R2 < R1: R2.Ratio
-    else: R1.Ratio
+    when R2 < R1: R2
+    else: R1
   let
     a {.inject.} = d1.to(Duration[commonRatio]).count
     b {.inject.} = d2.to(Duration[commonRatio]).count


### PR DESCRIPTION
These conversions were added to work around a Nim bug that has since been fixed on devel (seemingly in https://github.com/nim-lang/Nim/commit/f765898a7518f5c6bbebffd4217ccc35fd02747d).

Things that have to happen before merging:
* [x] The fix makes it to a Nim release (2.2.0?)
* [x] CI is updated to reflect the increased version requirement